### PR TITLE
Small fixes to raster surfaces and CPT

### DIFF
--- a/xsboringen/calc.py
+++ b/xsboringen/calc.py
@@ -27,10 +27,9 @@ class ExpLithologyRule(LithologyRule):
 
     def test(self, rf, qc):
         for limit in self.limits:
-            if (rf > limit.left) and (rf <= limit.right):
+            if (rf > limit.left) and (rf <= limit.right) and qc!=None:
                     return qc > limit.a*exp(limit.b*rf)
         return False
-
 
 class LithologyClassifier(object):
     def __init__(self, table, ruletype='exponential'):

--- a/xsboringen/rasterfiles.py
+++ b/xsboringen/rasterfiles.py
@@ -16,13 +16,26 @@ import os
 
 log = logging.getLogger(os.path.basename(__file__))
 
+# rio.DatasetReader.sample method does not work when trying to sample  
+# outside of the raster's spaial extent. This is a workaround.
+def take_rio_sample(dataset, coords):
+    ''' take sample from raster workaround method (simplified without rasterio.windows.Window) 
+    it yields np.nan if you look outside of the raster's spatial extent'''
+    for x,y in coords:
+        ix, iy = dataset.index(x, y)
+        if ix < dataset.shape[0] and iy < dataset.shape[1]:
+            yield [dataset.read()[0, ix, iy]]
+        else:
+            yield [np.nan]
 
 def sample_raster(rasterfile, coords):
     '''sample raster file at coords'''
     log.debug('reading rasterfile {}'.format(os.path.basename(rasterfile)))
     with rasterio.open(rasterfile) as src:
-        for value in src.sample(coords):
+        for value in take_rio_sample(src, coords):
             if value[0] in src.nodatavals:
+                yield np.nan
+            elif np.isnan(value[0]) and any(np.isnan(src.nodatavals)):
                 yield np.nan
             else:
                 yield float(value[0])
@@ -34,6 +47,8 @@ def sample_idf(idffile, coords):
     with idfpy.open(idffile) as src:
         for value in src.sample(coords):
             if value[0] == src.header['nodata']:
+                yield np.nan
+            elif np.isnan(value[0]) and any(np.isnan(src.header['nodata'])):
                 yield np.nan
             else:
                 yield float(value[0])

--- a/xsboringen/rasterfiles.py
+++ b/xsboringen/rasterfiles.py
@@ -23,10 +23,11 @@ def take_rio_sample(dataset, coords):
     it yields np.nan if you look outside of the raster's spatial extent'''
     for x,y in coords:
         ix, iy = dataset.index(x, y)
-        if ix < dataset.shape[0] and iy < dataset.shape[1]:
+        if ix < dataset.shape[0] and ix >= 0 and iy < dataset.shape[1] and iy >= 0:
             yield [dataset.read()[0, ix, iy]]
         else:
             yield [np.nan]
+
 
 def sample_raster(rasterfile, coords):
     '''sample raster file at coords'''


### PR DESCRIPTION
Three fixes, one being more of a workaround:

1. It is now possible to have a profile line outside of the raster's spatial extent without getting an IndexError
2. Fixed check for NaN values in rasters. This went wrong since np.nan == np.nan returns False. 
3. Ignore friction ratio if not available. Some CPT's don't have the luxury of a friction ratio and it would stop the program. If this is the case and translate_cpts = True in the config, a plot will look like this now:

![image](https://user-images.githubusercontent.com/11409383/113891043-fed9c180-97c4-11eb-9863-80b056a80045.png)

Geweldige package overigens. Stond op het punt zelf zoiets te ontwikkelen tot een collega me hier op wees. Zie maar wat je met de fixes doet, de workaround past misschien niet heel mooi in het geheel maar werkt en had ik nodig. Bedankt!

Groeten,
Erik van Onselen (Geoloog bij Deltares)